### PR TITLE
01/fixes

### DIFF
--- a/lumen.el
+++ b/lumen.el
@@ -69,7 +69,8 @@ Emacs and handle the ones that are intended for Lumen."
             ;; Slime messes with the keyboard shortcuts defined above
             ;; and shouldn't be necessary for editing Lumen files.
             (slime-mode -1)
-            (slime-autodoc-mode -1)))
+            (when (fboundp 'slime-autodoc-mode)
+              (slime-autodoc-mode -1))))
 
 ;;; Extend the Numen REPL for Lumen
 

--- a/numen.js
+++ b/numen.js
@@ -2,6 +2,9 @@ var vm = require('vm');
 var fs = require('fs');
 var net = require('net');
 
+var reader = require('reader');
+var compiler = require('compiler');
+
 global.D = v8debug.Debug; // the V8 debugger
 var S = null; // server
 var C = null; // client connection
@@ -22,7 +25,7 @@ function response (req) {
     } else if (req.load) {
         res = { 'loaded' : numenLoad(req.load, req.breakpoints) };
     } else if (req.compile) {
-        res = { 'compiled' : compile(expand(read_string(req.compile))) };
+        res = { 'compiled' : compiler.compile(compiler.expand(reader["read-string"](req.compile))) };
     } else if (req.source) {
         res = { 'script' : req.source, 'source' : source(req.source) };
     } else if (req.breakpoint) {
@@ -96,7 +99,7 @@ function evaluateAtTopLevel (code, breakAtStart) {
         D.breakExecution();
     }
     if (runningLumen) {
-        return clientValue(eval(read_string(code)));
+        return clientValue(compiler.eval(reader["read-string"](code)));
     } else {
         return clientValue(vm.runInThisContext(code, uniqueEvalScriptName()));
     }

--- a/numen.js
+++ b/numen.js
@@ -1,6 +1,7 @@
 var vm = require('vm');
 var fs = require('fs');
 var net = require('net');
+var child_process = require('child_process');
 
 var reader = require('reader');
 var compiler = require('compiler');
@@ -300,7 +301,11 @@ function runDebuggerLoop (exec_state) {
             }
         }
         catch (e) {
-            sendException(e);
+            if (e.code === 'EAGAIN') {
+                child_process.execSync("sleep 0.05");
+            } else {
+                sendException(e);
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fixes a few issues.

- In recent versions of Lumen, `read-string` is no longer a global function. Numen's code has been updated to account for this.

![image](https://cloud.githubusercontent.com/assets/16912082/17954667/f98c3254-6a41-11e6-9628-16dbb08e14e1.png)

- On OS X, the debugger loop throws EAGAIN exceptions when performing a blocking read. Numen now handles this case by sleeping for 50ms.

![image](https://cloud.githubusercontent.com/assets/16912082/17954711/5593edda-6a42-11e6-8030-d0bba89fb25c.png)

- Users with Slime installed don't necessarily have `slime-autodoc-mode`. Numen now handles this case.

