### PR TITLE
Define NUMEN-NODE and NUMEN-LUMEN

### DIFF
--- a/numen.el
+++ b/numen.el
@@ -159,6 +159,8 @@ window to display the buffer when it isn't already showing.")
 (defvar numen-input-ring nil)
 (defvar numen-input-ring-index nil)
 (defvar numen-lumen-p nil "When true, Numen sends code to a Lumen process; when false, to a Node.js process.")
+(defvar numen-lumen "lumen" "Program name for invoking Lumen lisp code")
+(defvar numen-node "node" "Program name for invoking Javascript code")
 (defvar numen-markers nil)
 (defvar numen-max-stored-eval-results nil)
 (defvar numen-port nil "Port by which Numen connects to a remote eval process.")
@@ -301,14 +303,14 @@ stack frames while debugging.
   "Launch an eval server as a child process and communicate with
 it using stdin and stdout. Called when `numen-host' is NIL."
   (when numen-lumen-p
-    (setenv "LUMEN_HOST" "node --expose_debug_as=v8debug"))
+    (setenv "LUMEN_HOST" (concat numen-node " --expose_debug_as=v8debug")))
   (let* ((process-connection-type nil) ; use a pipe, not a PTY. see Emacs documentation
          (buf (generate-new-buffer " *numen-childproc*")))
     (numen-init-evalproc
      (if numen-lumen-p
-         (apply 'start-process "lumen" buf "lumen"
+         (apply 'start-process numen-lumen buf numen-lumen
                 (list (concat numen-directory "numen.js") "-e" "(launchNumen 'lumen)"))
-       (apply 'start-process "node" buf "node"
+       (apply 'start-process numen-node buf numen-node
               (list "--expose_debug_as=v8debug" "-e"
                     (format "require('%snumen.js');launchNumen('js')" numen-directory)))))
     ;; tempdg: since start-process is async, put this elsewhere, like for socket


### PR DESCRIPTION
These variables specify the executable path to Node and Lumen. This allows the user to tell Numen to use different versions of `node` or `lumen`.

The motive for this is that Numen currently breaks on Node versions >= 5. To get around that, I install an old version of node via `nvm install` and set `numen-node` to it. That way Numen runs without forcing users to downgrade Node.

I spent this morning fixing the problems that prevent Numen from running on Node 5 through 7.9, so I'll submit more PRs for those.

(Frustratingly, Node >= 8 no longer supports `v8debug` at all. Supporting Node 7.9 will hopefully cover 90% of users for the next couple of years.)